### PR TITLE
Halve game speed (for 60 FPS support)

### DIFF
--- a/tzf_dsound/config.cpp
+++ b/tzf_dsound/config.cpp
@@ -49,6 +49,7 @@ struct {
   tzf::ParameterBool*    minimize_latency;
   tzf::ParameterInt*     speedresetcode_addr;
   tzf::ParameterInt*     speedresetcode2_addr;
+  tzf::ParameterInt*     speedresetcode3_addr;
 } framerate;
 
 struct {
@@ -207,6 +208,16 @@ TZF_LoadConfig (std::wstring name) {
       dll_ini,
       L"TZFIX.FrameRate",
       L"SpeedResetCode2_Address");
+
+  framerate.speedresetcode3_addr =
+      static_cast <tzf::ParameterInt *>
+      (g_ParameterFactory.create_parameter <int>(
+          L"Simulation Speed Reset Code 3 Memory Address")
+          );
+  framerate.speedresetcode3_addr->register_to_ini(
+      dll_ini,
+      L"TZFIX.FrameRate",
+      L"SpeedResetCode3_Address");
 
   render.aspect_ratio =
     static_cast <tzf::ParameterFloat *>
@@ -379,6 +390,9 @@ TZF_LoadConfig (std::wstring name) {
   if (framerate.speedresetcode2_addr->load())
       config.framerate.speedresetcode2_addr = framerate.speedresetcode2_addr->get_value();
 
+  if (framerate.speedresetcode3_addr->load())
+      config.framerate.speedresetcode3_addr = framerate.speedresetcode_addr->get_value();
+
 
 
   if (render.aspect_addr->load ())
@@ -465,6 +479,9 @@ TZF_SaveConfig (std::wstring name, bool close_config) {
 
   framerate.speedresetcode2_addr->set_value(config.framerate.speedresetcode2_addr);
   framerate.speedresetcode2_addr->store();
+
+  framerate.speedresetcode3_addr->set_value(config.framerate.speedresetcode3_addr);
+  framerate.speedresetcode3_addr->store();
 
 
 

--- a/tzf_dsound/config.cpp
+++ b/tzf_dsound/config.cpp
@@ -391,7 +391,7 @@ TZF_LoadConfig (std::wstring name) {
       config.framerate.speedresetcode2_addr = framerate.speedresetcode2_addr->get_value();
 
   if (framerate.speedresetcode3_addr->load())
-      config.framerate.speedresetcode3_addr = framerate.speedresetcode_addr->get_value();
+      config.framerate.speedresetcode3_addr = framerate.speedresetcode3_addr->get_value();
 
 
 

--- a/tzf_dsound/config.cpp
+++ b/tzf_dsound/config.cpp
@@ -47,8 +47,8 @@ struct {
   tzf::ParameterBool*    yield_processor;
   tzf::ParameterBool*    allow_windowed_mode;
   tzf::ParameterBool*    minimize_latency;
-  tzf::ParameterInt*     speed_addr;
   tzf::ParameterInt*     speedresetcode_addr;
+  tzf::ParameterInt*     speedresetcode2_addr;
 } framerate;
 
 struct {
@@ -188,16 +188,6 @@ TZF_LoadConfig (std::wstring name) {
       L"TZFIX.FrameRate",
         L"MinimizeLatency" );
 
-  framerate.speed_addr =
-      static_cast <tzf::ParameterInt *>
-      (g_ParameterFactory.create_parameter <int>(
-          L"Simulation Speed Memory Address")
-          );
-  framerate.speed_addr->register_to_ini(
-      dll_ini,
-      L"TZFIX.FrameRate",
-      L"Speed_Address");
-
   framerate.speedresetcode_addr =
       static_cast <tzf::ParameterInt *>
       (g_ParameterFactory.create_parameter <int>(
@@ -208,6 +198,15 @@ TZF_LoadConfig (std::wstring name) {
       L"TZFIX.FrameRate",
       L"SpeedResetCode_Address");
 
+  framerate.speedresetcode2_addr =
+      static_cast <tzf::ParameterInt *>
+      (g_ParameterFactory.create_parameter <int>(
+          L"Simulation Speed Reset Code 2 Memory Address")
+          );
+  framerate.speedresetcode2_addr->register_to_ini(
+      dll_ini,
+      L"TZFIX.FrameRate",
+      L"SpeedResetCode2_Address");
 
   render.aspect_ratio =
     static_cast <tzf::ParameterFloat *>
@@ -374,11 +373,11 @@ TZF_LoadConfig (std::wstring name) {
   if (framerate.minimize_latency->load ())
     config.framerate.minimize_latency = framerate.minimize_latency->get_value ();
 
-  if (framerate.speed_addr->load())
-      config.framerate.speed_addr = framerate.speed_addr->get_value();
-
   if (framerate.speedresetcode_addr->load())
       config.framerate.speedresetcode_addr = framerate.speedresetcode_addr->get_value();
+
+  if (framerate.speedresetcode2_addr->load())
+      config.framerate.speedresetcode2_addr = framerate.speedresetcode2_addr->get_value();
 
 
 
@@ -461,11 +460,11 @@ TZF_SaveConfig (std::wstring name, bool close_config) {
   framerate.minimize_latency->set_value (config.framerate.minimize_latency);
   framerate.minimize_latency->store     ();
 
-  framerate.speed_addr->set_value(config.framerate.speed_addr);
-  framerate.speed_addr->store();
-
   framerate.speedresetcode_addr->set_value(config.framerate.speedresetcode_addr);
   framerate.speedresetcode_addr->store();
+
+  framerate.speedresetcode2_addr->set_value(config.framerate.speedresetcode2_addr);
+  framerate.speedresetcode2_addr->store();
 
 
 

--- a/tzf_dsound/config.cpp
+++ b/tzf_dsound/config.cpp
@@ -47,6 +47,8 @@ struct {
   tzf::ParameterBool*    yield_processor;
   tzf::ParameterBool*    allow_windowed_mode;
   tzf::ParameterBool*    minimize_latency;
+  tzf::ParameterInt*     speed_addr;
+  tzf::ParameterInt*     speedresetcode_addr;
 } framerate;
 
 struct {
@@ -185,6 +187,26 @@ TZF_LoadConfig (std::wstring name) {
     dll_ini,
       L"TZFIX.FrameRate",
         L"MinimizeLatency" );
+
+  framerate.speed_addr =
+      static_cast <tzf::ParameterInt *>
+      (g_ParameterFactory.create_parameter <int>(
+          L"Simulation Speed Memory Address")
+          );
+  framerate.speed_addr->register_to_ini(
+      dll_ini,
+      L"TZFIX.FrameRate",
+      L"Speed_Address");
+
+  framerate.speedresetcode_addr =
+      static_cast <tzf::ParameterInt *>
+      (g_ParameterFactory.create_parameter <int>(
+          L"Simulation Speed Reset Code Memory Address")
+          );
+  framerate.speedresetcode_addr->register_to_ini(
+      dll_ini,
+      L"TZFIX.FrameRate",
+      L"SpeedResetCode_Address");
 
 
   render.aspect_ratio =
@@ -352,6 +374,12 @@ TZF_LoadConfig (std::wstring name) {
   if (framerate.minimize_latency->load ())
     config.framerate.minimize_latency = framerate.minimize_latency->get_value ();
 
+  if (framerate.speed_addr->load())
+      config.framerate.speed_addr = framerate.speed_addr->get_value();
+
+  if (framerate.speedresetcode_addr->load())
+      config.framerate.speedresetcode_addr = framerate.speedresetcode_addr->get_value();
+
 
 
   if (render.aspect_addr->load ())
@@ -432,6 +460,14 @@ TZF_SaveConfig (std::wstring name, bool close_config) {
 
   framerate.minimize_latency->set_value (config.framerate.minimize_latency);
   framerate.minimize_latency->store     ();
+
+  framerate.speed_addr->set_value(config.framerate.speed_addr);
+  framerate.speed_addr->store();
+
+  framerate.speedresetcode_addr->set_value(config.framerate.speedresetcode_addr);
+  framerate.speedresetcode_addr->store();
+
+
 
 
   render.aspect_addr->set_value (config.render.aspect_addr);

--- a/tzf_dsound/config.h
+++ b/tzf_dsound/config.h
@@ -37,14 +37,14 @@ struct tzf_config_t
   } audio;
 
   struct {
-    bool  yield_processor     = true;
-    bool  allow_fake_sleep    = false;
-    bool  stutter_fix         = true;
-    float fudge_factor        = 1.666f;
-    bool  allow_windowed_mode = false;
-    bool  minimize_latency    = false;
-    DWORD speed_addr          = 0x0217B3D4;
-    DWORD speedresetcode_addr = 0x0046C529;
+    bool  yield_processor      = true;
+    bool  allow_fake_sleep     = false;
+    bool  stutter_fix          = true;
+    float fudge_factor         = 1.666f;
+    bool  allow_windowed_mode  = false;
+    bool  minimize_latency     = false;
+    DWORD speedresetcode_addr  = 0x0046C529;
+    DWORD speedresetcode2_addr = 0x0056E441;
   } framerate;
 
   struct {

--- a/tzf_dsound/config.h
+++ b/tzf_dsound/config.h
@@ -45,6 +45,7 @@ struct tzf_config_t
     bool  minimize_latency     = false;
     DWORD speedresetcode_addr  = 0x0046C529;
     DWORD speedresetcode2_addr = 0x0056E441;
+    DWORD speedresetcode3_addr = 0x0056D93F;
   } framerate;
 
   struct {

--- a/tzf_dsound/config.h
+++ b/tzf_dsound/config.h
@@ -43,6 +43,8 @@ struct tzf_config_t
     float fudge_factor        = 1.666f;
     bool  allow_windowed_mode = false;
     bool  minimize_latency    = false;
+    DWORD speed_addr          = 0x0217B3D4;
+    DWORD speedresetcode_addr = 0x0046C529;
   } framerate;
 
   struct {

--- a/tzf_dsound/framerate.cpp
+++ b/tzf_dsound/framerate.cpp
@@ -268,6 +268,11 @@ tzf::FrameRateFix::Init (void)
     memcpy((LPVOID)config.framerate.speedresetcode2_addr, &new_code, 7);
     VirtualProtect((LPVOID)config.framerate.speedresetcode2_addr, 7, dwOld, &dwOld);
 
+    // mov eax, 02 to mov eax, 01
+    VirtualProtect((LPVOID)config.framerate.speedresetcode3_addr, 4, PAGE_EXECUTE_READWRITE, &dwOld);
+    *((DWORD *)config.framerate.speedresetcode3_addr) = 1;
+    VirtualProtect((LPVOID)config.framerate.speedresetcode3_addr, 4, dwOld, &dwOld);
+
     half_speed_installed = true;
   }
 
@@ -309,6 +314,10 @@ tzf::FrameRateFix::Shutdown(void)
     VirtualProtect((LPVOID)config.framerate.speedresetcode2_addr, 7, PAGE_EXECUTE_READWRITE, &dwOld);
     memcpy((LPVOID)config.framerate.speedresetcode2_addr, &old_speed_reset_code2, 7);
     VirtualProtect((LPVOID)config.framerate.speedresetcode2_addr, 7, dwOld, &dwOld);
+
+    VirtualProtect((LPVOID)config.framerate.speedresetcode3_addr, 4, PAGE_EXECUTE_READWRITE, &dwOld);
+    *((DWORD *)config.framerate.speedresetcode3_addr) = 2;
+    VirtualProtect((LPVOID)config.framerate.speedresetcode3_addr, 4, dwOld, &dwOld);
 
     half_speed_installed = false;
   }


### PR DESCRIPTION
As discussed, here's a patch that halves Zestiria's simulation speed, letting us run the game at 60 FPS in real time.

For reference / future game updates: addresses were found by looking around for 1/30 in memory and tracing through related code. There's two integer speed multipliers, initially set to 2 at `SpeedResetCode3_Address`, as part of a structure at a static address. I found they get copied over from an object, or reset if lower than 2, upon some state changes (e.g. loading a save or entering a cutscene), hence I patch the code that does this at `SpeedResetCode_Address` and `SpeedResetCode2_Address` to skip these particular multipliers.

The size of said structure is not hardcoded to allow for at least some flexibility to game updates - should its base address and the location and syntax of the code copying it stay the same, this patch will continue to function even if the structure gets expanded *after* the part we care about.

The patch is activated if the target framerate is above 45 and thus running the game at 50% speed gets us closer to real time than 100%.

In addition, I change the FudgeFactor internally (i.e. not saved to config) according to the target framerate, as I've noticed the default 1.666 is inadequate when targeting 60 FPS, causing slowdowns of about 1/6 in busy town areas.

Note **this is not yet shippable**, as the target framerate is hardcoded to 60 for now. As we talked about, this value should be looked up from BMF.

Once that is implemented, no further configuration changes than setting `targetFPS=60` in BMF's config are necessary to activate this patch.

Best regards,
Niklas.