### PR TITLE
fix speed not being reset after FMVs followed by skits

### DIFF
--- a/tzf_dsound/framerate.cpp
+++ b/tzf_dsound/framerate.cpp
@@ -446,12 +446,12 @@ tzf::FrameRateFix::Allow60FPS (void)
   if (half_speed_installed) {
     DWORD dwOld;
 
-    //VirtualProtect ((LPVOID)0x0217B3D4, 4, PAGE_EXECUTE_READWRITE, &dwOld);
-    //VirtualProtect ((LPVOID)0x0217B3D8, 4, PAGE_EXECUTE_READWRITE, &dwOld);
-                  //*((DWORD *)0x0217B3D4) = 1;
-                  //*((DWORD *)0x0217B3D8) = 1;
-    //VirtualProtect ((LPVOID)0x0217B3D4, 4, dwOld, &dwOld);
-    //VirtualProtect ((LPVOID)0x0217B3D8, 4, dwOld, &dwOld);
+    VirtualProtect ((LPVOID)0x0217B3D4, 4, PAGE_EXECUTE_READWRITE, &dwOld);
+    VirtualProtect ((LPVOID)0x0217B3D8, 4, PAGE_EXECUTE_READWRITE, &dwOld);
+                  *((DWORD *)0x0217B3D4) = 1;
+                  *((DWORD *)0x0217B3D8) = 1;
+    VirtualProtect ((LPVOID)0x0217B3D4, 4, dwOld, &dwOld);
+    VirtualProtect ((LPVOID)0x0217B3D8, 4, dwOld, &dwOld);
   }
 
   LeaveCriticalSection (&half_speed_cs);


### PR DESCRIPTION
Issue reported to me by Shinrin Cole: Apparently game speed does *not* reset itself after FMVs that are followed by skits.

Untested, but I'm pretty sure this should fix that.